### PR TITLE
Add apiUri as a required option

### DIFF
--- a/example-with-css.css
+++ b/example-with-css.css
@@ -43,7 +43,8 @@
   display: block;
   width: 100%;
   border-radius: 4px;
-  transition: all 0.25s cubic-bezier(0.785, 0.135, 0.15, 0.86) 0s;
+  /* AEM seems to strip the `s` off if you specify a delay of `0s`, so `0.1ms` is a near zero value */
+  transition: all 0.25s cubic-bezier(0.785, 0.135, 0.15, 0.86) 0.1ms;
 }
 .cru-recommendations-component .cru-recommendations-component-category {
   font-size: 14px;

--- a/example-with-css.html
+++ b/example-with-css.html
@@ -18,13 +18,14 @@
 
     <script src="./index.ts"></script>
     <script>
-      window.cruRecommendationsComponent.render(
-        document.querySelector('#cru-recommendations-component-with-css'),
-        {
-          uri:
-            'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
-        },
-      );
+      window.cruRecommendationsComponent.render({
+        container: document.querySelector(
+          '#cru-recommendations-component-with-css',
+        ),
+        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        pageUri:
+          'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
+      });
     </script>
   </body>
 </html>

--- a/example-with-css.html
+++ b/example-with-css.html
@@ -22,7 +22,7 @@
         container: document.querySelector(
           '#cru-recommendations-component-with-css',
         ),
-        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        prod: false,
         pageUri:
           'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
       });

--- a/example-with-custom-classes.html
+++ b/example-with-custom-classes.html
@@ -14,7 +14,7 @@
         container: document.querySelector(
           '#cru-recommendations-component-with-custom-classes',
         ),
-        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        prod: false,
         pageUri:
           'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
         classNames: {

--- a/example-with-custom-classes.html
+++ b/example-with-custom-classes.html
@@ -10,22 +10,21 @@
 
     <script src="./index.ts"></script>
     <script>
-      window.cruRecommendationsComponent.render(
-        document.querySelector(
+      window.cruRecommendationsComponent.render({
+        container: document.querySelector(
           '#cru-recommendations-component-with-custom-classes',
         ),
-        {
-          uri:
-            'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
-          classNames: {
-            wrapper: 'example-wrapper',
-            card: 'example-card',
-            image: 'example-image',
-            title: 'example-title',
-            description: 'example-description',
-          },
+        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        pageUri:
+          'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
+        classNames: {
+          wrapper: 'example-wrapper',
+          card: 'example-card',
+          image: 'example-image',
+          title: 'example-title',
+          description: 'example-description',
         },
-      );
+      });
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,13 +18,12 @@
 
     <script src="./index.ts"></script>
     <script>
-      window.cruRecommendationsComponent.render(
-        document.querySelector('#cru-recommendations-component'),
-        {
-          uri:
-            'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
-        },
-      );
+      window.cruRecommendationsComponent.render({
+        container: document.querySelector('#cru-recommendations-component'),
+        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        pageUri:
+          'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
+      });
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <script>
       window.cruRecommendationsComponent.render({
         container: document.querySelector('#cru-recommendations-component'),
-        apiUri: 'https://cru-content-based-filtering-stage.s3.amazonaws.com/',
+        prod: false,
         pageUri:
           'https://www.cru.org/us/en/about/partners/a-surprise-in-one-of-baltimores-toughest-neighborhoods.html',
       });

--- a/index.ts
+++ b/index.ts
@@ -5,8 +5,6 @@ interface Recommendation {
   category: string;
 }
 
-const apiUri = 'https://cru-content-based-filtering.s3.amazonaws.com/';
-
 interface CssClasses {
   wrapper: string;
   header: string;
@@ -58,15 +56,21 @@ ${recommendations.reduce(
 `;
 
 export const cruRecommendationsComponent = {
-  render: async (
-    container: Element,
-    {
-      uri = window.location.href,
-      classNames,
-    }: { uri?: string; classNames?: Partial<CssClasses> } = {},
-  ) => {
+  render: async ({
+    container,
+    apiUri,
+    pageUri = window.location.href,
+    classNames,
+  }: {
+    container: Element;
+    apiUri: string;
+    pageUri?: string;
+    classNames?: Partial<CssClasses>;
+  }) => {
     try {
-      const response = await fetch(`${apiUri}${encodeURIComponent(uri)}.json`);
+      const response = await fetch(
+        `${apiUri}${encodeURIComponent(pageUri)}.json`,
+      );
       if (!response.ok) {
         throw new Error(response.statusText);
       }

--- a/index.ts
+++ b/index.ts
@@ -58,18 +58,22 @@ ${recommendations.reduce(
 export const cruRecommendationsComponent = {
   render: async ({
     container,
-    apiUri,
+    prod = false,
     pageUri = window.location.href,
     classNames,
   }: {
     container: Element;
-    apiUri: string;
+    prod?: boolean;
     pageUri?: string;
     classNames?: Partial<CssClasses>;
   }) => {
     try {
       const response = await fetch(
-        `${apiUri}${encodeURIComponent(pageUri)}.json`,
+        `${
+          prod
+            ? 'https://cru-content-based-filtering-prod.s3.amazonaws.com'
+            : 'https://cru-content-based-filtering-stage.s3.amazonaws.com'
+        }/${encodeURIComponent(pageUri)}.json`,
       );
       if (!response.ok) {
         throw new Error(response.statusText);


### PR DESCRIPTION
- Refactor all options into an object
- Add CSS hack for AEM issue

I'm waiting on infrastructure and plan to rename the
`https://cru-content-based-filtering.s3.amazonaws.com/`
bucket to
`https://cru-content-based-filtering-prod.s3.amazonaws.com/` and
`https://cru-content-based-filtering-stage.s3.amazonaws.com/`
which is reflected in my examples.