### PR TITLE
Update to h2

### DIFF
--- a/example-with-css.css
+++ b/example-with-css.css
@@ -9,7 +9,6 @@
   color: #383f43;
   text-decoration: none;
 }
-.cru-recommendations-component h1,
 .cru-recommendations-component h2,
 .cru-recommendations-component h3 {
   margin: 0;

--- a/example-with-css.html
+++ b/example-with-css.html
@@ -6,7 +6,7 @@
   <body>
     <a href="./">&lt; Back</a>
 
-    <h1>Example Recommendations Component with CSS</h1>
+    <h2>Example Recommendations Component with CSS</h2>
     <style>
       @media (min-width: 992px) {
         #cru-recommendations-component-with-css {

--- a/example-with-custom-classes.html
+++ b/example-with-custom-classes.html
@@ -5,7 +5,7 @@
   <body>
     <a href="./">&lt; Back</a>
 
-    <h1>Example Recommendations Component with custom classes</h1>
+    <h2>Example Recommendations Component with custom classes</h2>
     <div id="cru-recommendations-component-with-custom-classes"></div>
 
     <script src="./index.ts"></script>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <title>Recommendations Component Example</title>
   </head>
   <body>
-    <h1>Example Recommendations Component</h1>
+    <h2>Example Recommendations Component</h2>
     <ul>
       <li>
         <a href="example-with-custom-classes.html">

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ const recommendationsToHTML = (
   hideCategory,
 ) => `
 <div class="${classes.wrapper}">
-  <h1 class="${classes.header}">Recommended Articles</h1>
+  <h2 class="${classes.header}">Recommended Articles</h2>
 ${recommendations.reduce(
   (output, { title, category, uri, imageUri }, index) =>
     `${output}


### PR DESCRIPTION
For SEO purposes, we don't want to use `h1` because there is already an `h1` on the pages including this component. Since the CSS is done against the class name and not the element type, this does not change the look.

[Asana](https://app.asana.com/0/1196945912362083/1200152072600826)